### PR TITLE
chore: add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gradle"
     commit-message:
       prefix: "chore"
@@ -21,6 +23,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "maven"
     commit-message:
       prefix: "chore"
@@ -35,6 +39,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     commit-message:
       prefix: "chore"
@@ -50,3 +56,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Delays Dependabot version updates by 7 days after a new release is
published. This reduces exposure to supply-chain attacks (malicious
or compromised packages are typically caught and pulled within days
of publication) and supports SOC 2 change-management controls around
vetted, non-immediate dependency updates.

Adds a `cooldown: default-days: 7` block to each `updates` entry in
`.github/dependabot.yml`. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/reducing-the-number-of-pull-requests-dependabot-opens#configuring-cooldown-options
